### PR TITLE
Implement health reporting and audit hash-chain safeguards

### DIFF
--- a/co-platform-expanded-final/co-platform/README.md
+++ b/co-platform-expanded-final/co-platform/README.md
@@ -183,13 +183,38 @@ detail page. The current implementation is naive; integrate a proper
 search engine (e.g. PostgreSQL full‑text search or Elasticsearch) for
 production use.
 
-## Audit Logs
+## Audit Logs & Integrity
 
-Audit logs are available via the API at `/audit-logs/` (clearance ≥ 5
-required). The UI does not yet expose them. To record actions, add
-`AuditLog` creation calls in each router (e.g. when approvals are updated
-or webhooks are modified). Extend the Audit endpoints and build a
-frontend view to explore audit records.
+Audit logs are now available under the `/audit` namespace (clearance ≥ 5
+required):
+
+- `GET /audit/logs` returns the ordered audit feed.
+- `GET /audit/verify-hash-chain` validates the tamper-evident hash chain
+  and reports any gaps.
+- `GET /audit/export?fmt=json|csv` exports the log with a detached HMAC
+  signature so the payload can be verified offline.
+
+To record actions, add `AuditLog` creation calls in each router (e.g.
+when approvals are updated or webhooks are modified). Extend the Audit
+endpoints and build a frontend view to explore audit records.
+
+Nightly jobs automatically verify the audit chain and log outcomes in
+the audit trail. Failures raise alerts that surface in the System Health
+widget.
+
+## System Health & Nightly Operations
+
+The backend exposes `/health`, `/ready` and `/metrics` endpoints. These
+drive the dashboard’s System Health card and can be scraped by external
+monitoring. The health report lists any degraded components rather than
+failing outright so the application remains usable while services are
+restored.
+
+Nightly maintenance runs at 02:00 UTC and performs probation reminders,
+retention cleanup (respecting legal holds and extensions), simulated
+database backups (retaining 14 days), audit hash-chain verification and
+IMAP ticket ingestion. Results are written to the audit log and any
+failures trigger alerts that appear in `/health`.
 
 ## Security & Permissions
 
@@ -220,10 +245,11 @@ frontend view to explore audit records.
   routers: create an approval record when a request is made and require an
   approval before changing the request status.
 * **Retention & audit** – use the `/retention/cleanup` endpoint (requires
-  the `privacy.retention` permission) to purge records older than a
-  specified number of years. Schedule this operation periodically (e.g.
-  via cron). Record actions via `AuditLog` by adding logging statements to
-  your endpoints.
+  the `privacy.retention` permission) to purge or anonymise records older
+  than the default four-year window. Extensions can be managed via
+  `/retention/extensions` to respect legal holds granted by the
+  Information Assurance Council. Record actions via `AuditLog` by adding
+  logging statements to your endpoints.
 * **DSAR exports** – call `/dsar/{user_id}` from a user account (for your
   own data) or from an account with the `privacy.dsar` permission to obtain
   a JSON document containing all data about the specified user. The

--- a/co-platform-expanded-final/co-platform/backend/app/main.py
+++ b/co-platform-expanded-final/co-platform/backend/app/main.py
@@ -1,17 +1,15 @@
-"""Entry point for the FastAPI application.
+"""Entry point for the FastAPI application."""
 
-This module creates the FastAPI app, includes all routers, and sets up
-middleware such as CORS. On startup it initialises the database
-schema if necessary.
-"""
-
+import asyncio
 import os
-from typing import List
+import time
+from contextlib import suppress
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 
-from .database import Base, engine
+from .database import Base, SessionLocal, engine
 from .routers import (
     auth,
     users,
@@ -32,7 +30,10 @@ from .routers import (
     audit,
     dsar,
     retention,
+    health,
 )
+from .services.jobs import nightly_job_manager
+from .services.metrics import metrics_collector
 
 
 def create_app() -> FastAPI:
@@ -40,6 +41,7 @@ def create_app() -> FastAPI:
 
     # Initialise database tables
     Base.metadata.create_all(bind=engine)
+    nightly_job_manager.configure(SessionLocal)
 
     # Configure CORS
     allowed_origins = os.getenv("ALLOWED_ORIGINS", "").split(",")
@@ -74,14 +76,40 @@ def create_app() -> FastAPI:
     app.include_router(attachments.router)
     app.include_router(search.router)
     app.include_router(audit.router)
+    app.include_router(audit.legacy_router)
     app.include_router(dsar.router)
     app.include_router(retention.router)
+    app.include_router(health.router)
+
+    @app.middleware("http")
+    async def record_metrics(request: Request, call_next):  # type: ignore[override]
+        start = time.perf_counter()
+        success = False
+        try:
+            response = await call_next(request)
+            success = response.status_code < 500
+            return response
+        finally:
+            duration = time.perf_counter() - start
+            metrics_collector.record_request(request.url.path, duration, success)
+
+    @app.on_event("startup")
+    async def start_nightly_jobs() -> None:
+        app.state.nightly_task = asyncio.create_task(nightly_job_manager.run_scheduler())
+
+    @app.on_event("shutdown")
+    async def stop_nightly_jobs() -> None:
+        nightly_job_manager.stop()
+        task = getattr(app.state, "nightly_task", None)
+        if task:
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
 
     # Serve static HTML pages and assets from the ``static`` directory. This
     # allows a simple browser-based front‑end without requiring a separate
     # build step. Any path that does not match an API endpoint will fall
     # through to the static files handler.
-    from fastapi.staticfiles import StaticFiles
     static_dir = os.path.join(os.path.dirname(__file__), "static")
     app.mount("/", StaticFiles(directory=static_dir, html=True), name="static")
 

--- a/co-platform-expanded-final/co-platform/backend/app/models.py
+++ b/co-platform-expanded-final/co-platform/backend/app/models.py
@@ -394,5 +394,21 @@ class AuditLog(Base):
     entity_id = Column(Integer, nullable=True)
     timestamp = Column(Date, nullable=False)
     details = Column(Text, nullable=True)
+    prev_hash = Column(String, nullable=True)
+    entry_hash = Column(String, nullable=True)
+    retention_expires_at = Column(Date, nullable=True)
+    legal_hold = Column(Boolean, default=False, nullable=False)
 
     user = relationship("User", backref="audit_logs")
+
+
+class RetentionExtension(Base):
+    """Records retention overrides authorised by the Information Assurance Council."""
+
+    __tablename__ = "retention_extensions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    entity_type = Column(String, nullable=False)
+    entity_id = Column(Integer, nullable=False)
+    extended_until = Column(Date, nullable=False)
+    reason = Column(Text, nullable=True)

--- a/co-platform-expanded-final/co-platform/backend/app/routers/audit.py
+++ b/co-platform-expanded-final/co-platform/backend/app/routers/audit.py
@@ -1,29 +1,64 @@
-"""Audit log endpoints.
-
-This router exposes a read-only view of the audit log. Only users with
-clearance >= 5 may view audit entries. Recording audit entries must be
-implemented in each individual router or via middleware; currently not
-all endpoints log actions.
-"""
+"""Audit log endpoints including hash chain verification and export."""
 
 from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 from .. import models, schemas
-from ..dependencies import get_db, get_current_user
+from ..dependencies import get_current_user, get_db
 from ..security import has_permission
+from ..services.audit_chain import export_audit_logs, verify_hash_chain
 
-router = APIRouter(prefix="/audit-logs", tags=["audit"])
+router = APIRouter(prefix="/audit", tags=["audit"])
+legacy_router = APIRouter(prefix="/audit-logs", tags=["audit"])
 
 
-@router.get("/", response_model=List[schemas.AuditLogOut])
+@router.get("/logs", response_model=List[schemas.AuditLogOut])
 def list_audit_logs(
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
 ):
-    """List all audit log entries. Requires admin clearance."""
     if not has_permission(current_user, "audit.view", db):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient privileges")
     return db.query(models.AuditLog).order_by(models.AuditLog.id).all()
+
+
+@router.get("/verify-hash-chain")
+def verify_chain(
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    if not has_permission(current_user, "audit.view", db):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient privileges")
+    report = verify_hash_chain(db)
+    return {
+        "status": report.status,
+        "entries_checked": report.entries_checked,
+        "issues": report.issues,
+    }
+
+
+@router.get("/export")
+def export_logs(
+    fmt: str = Query("json", pattern="^(json|csv)$"),
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    if not has_permission(current_user, "audit.view", db):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient privileges")
+    payload, signature, mime = export_audit_logs(db, fmt)
+    return {
+        "format": fmt,
+        "mime": mime,
+        "payload": payload,
+        "signature": signature,
+    }
+
+
+@legacy_router.get("/", response_model=List[schemas.AuditLogOut])
+def legacy_list(
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    return list_audit_logs(db=db, current_user=current_user)

--- a/co-platform-expanded-final/co-platform/backend/app/routers/health.py
+++ b/co-platform-expanded-final/co-platform/backend/app/routers/health.py
@@ -1,0 +1,26 @@
+"""System health and readiness endpoints."""
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import PlainTextResponse
+from sqlalchemy.orm import Session
+
+from ..dependencies import get_db
+from ..services.health import build_health_report, readiness_check
+from ..services.metrics import metrics_collector
+
+router = APIRouter(prefix="", tags=["health"])
+
+
+@router.get("/health")
+def health(db: Session = Depends(get_db)) -> dict:
+    return build_health_report(db)
+
+
+@router.get("/ready")
+def ready(db: Session = Depends(get_db)) -> dict:
+    return readiness_check(db)
+
+
+@router.get("/metrics", response_class=PlainTextResponse)
+def metrics() -> PlainTextResponse:
+    return PlainTextResponse(metrics_collector.render_prometheus(), media_type="text/plain")

--- a/co-platform-expanded-final/co-platform/backend/app/routers/retention.py
+++ b/co-platform-expanded-final/co-platform/backend/app/routers/retention.py
@@ -1,82 +1,63 @@
-"""Data retention management endpoints.
+"""Data retention management endpoints."""
 
-This router implements a simple cleanup routine to purge records older
-than a configurable retention period (default four years). It is
-designed to support compliance with privacy regulations by removing
-outdated data from the database. In a production system, such cleanup
-would likely run as a scheduled job; however, for demonstration
-purposes it is exposed as a POST endpoint that administrators can
-invoke manually.
+from typing import Dict, List
 
-Only users with a clearance level of 5 or higher may trigger the
-cleanup. The endpoint iterates through leave requests, tickets,
-incidents, appeals, brag entries, probations, training records,
-offboarding records, attachments and audit logs, deleting those with
-dates (or creation dates) older than ``retention_years``.
-"""
-
-from datetime import date, timedelta
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
-from typing import Dict
 
-from .. import models
-from ..dependencies import get_db, get_current_user
+from .. import models, schemas
+from ..dependencies import get_current_user, get_db
 from ..security import has_permission
+from ..services import retention as retention_service
 
 router = APIRouter(prefix="/retention", tags=["retention"])
 
 
-@router.post("/cleanup")
+@router.post("/cleanup", response_model=Dict[str, Dict[str, int]])
 def cleanup_expired(
-    retention_years: int = 4,
+    retention_years: int = retention_service.DEFAULT_RETENTION_YEARS,
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
-    ) -> Dict[str, int]:
-    """Delete records older than ``retention_years`` years.
-
-    The function returns a dictionary summarising the number of records
-    deleted per entity type. Only administrators (clearance >= 5) may
-    invoke this endpoint.
-    """
-    # Require the privacy.retention permission (superusers bypass via has_permission)
+) -> Dict[str, Dict[str, int]]:
     if not has_permission(current_user, "privacy.retention", db):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient privileges")
-    cutoff = date.today() - timedelta(days=retention_years * 365)
-    counts: Dict[str, int] = {}
-    # Helper to delete records with a date field
-    def purge(queryset, date_field: str, name: str) -> None:
-        nonlocal counts
-        to_delete = queryset.filter(getattr(models, name).__table__.c[date_field] < cutoff).all()
-        counts[name] = len(to_delete)
-        for obj in to_delete:
-            db.delete(obj)
+    return retention_service.cleanup_expired_records(db, retention_years=retention_years)
 
-    # Purge each model with a date field
-    # Leaves: end_date used for retention
-    purge(db.query(models.LeaveRequest), 'end_date', 'LeaveRequest')
-    # Tickets: no date field -> skip (tickets are not time-bound and are retained unless manually deleted)
-    # Incidents: date field
-    purge(db.query(models.Incident), 'date', 'Incident')
-    # Appeals: created_at
-    purge(db.query(models.Appeal), 'created_at', 'Appeal')
-    # BRAG entries: date
-    purge(db.query(models.BragEntry), 'date', 'BragEntry')
-    # Probations: end_date
-    purge(db.query(models.ProbationStatus), 'end_date', 'ProbationStatus')
-    # Training: completion_date (if completed), or skip if not completed
-    to_delete_training = db.query(models.TrainingStatus).filter(
-        models.TrainingStatus.completed == True,
-        models.TrainingStatus.completion_date < cutoff,
-    ).all()
-    counts['TrainingStatus'] = len(to_delete_training)
-    for t in to_delete_training:
-        db.delete(t)
-    # Offboarding: date
-    purge(db.query(models.Offboarding), 'date', 'Offboarding')
-    # Attachments: uploaded_at
-    purge(db.query(models.Attachment), 'uploaded_at', 'Attachment')
-    # Audit logs: timestamp
-    purge(db.query(models.AuditLog), 'timestamp', 'AuditLog')
-    db.commit()
-    return counts
+
+@router.get("/extensions", response_model=List[schemas.RetentionExtensionOut])
+def list_extensions(
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> List[schemas.RetentionExtensionOut]:
+    if not has_permission(current_user, "privacy.retention", db):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient privileges")
+    return db.query(models.RetentionExtension).order_by(models.RetentionExtension.extended_until.desc()).all()
+
+
+@router.post("/extensions", response_model=schemas.RetentionExtensionOut)
+def create_extension(
+    payload: schemas.RetentionExtensionCreate,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> schemas.RetentionExtensionOut:
+    if not has_permission(current_user, "privacy.retention", db):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient privileges")
+    record = retention_service.upsert_extension(
+        db,
+        entity_type=payload.entity_type,
+        entity_id=payload.entity_id,
+        extended_until=payload.extended_until,
+        reason=payload.reason,
+    )
+    return record
+
+
+@router.delete("/extensions/{extension_id}", status_code=204)
+def delete_extension(
+    extension_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> None:
+    if not has_permission(current_user, "privacy.retention", db):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient privileges")
+    retention_service.delete_extension(db, extension_id)

--- a/co-platform-expanded-final/co-platform/backend/app/schemas.py
+++ b/co-platform-expanded-final/co-platform/backend/app/schemas.py
@@ -311,6 +311,24 @@ class AuditLogOut(BaseModel):
     entity_id: Optional[int]
     timestamp: date
     details: Optional[str]
+    prev_hash: Optional[str]
+    entry_hash: Optional[str]
+    retention_expires_at: Optional[date]
+    legal_hold: bool
+
+    class Config:
+        from_attributes = True
+
+
+class RetentionExtensionCreate(BaseModel):
+    entity_type: str
+    entity_id: int
+    extended_until: date
+    reason: Optional[str] = None
+
+
+class RetentionExtensionOut(RetentionExtensionCreate):
+    id: int
 
     class Config:
         from_attributes = True

--- a/co-platform-expanded-final/co-platform/backend/app/services/audit_chain.py
+++ b/co-platform-expanded-final/co-platform/backend/app/services/audit_chain.py
@@ -1,0 +1,163 @@
+"""Helpers for managing the tamper-evident audit hash chain."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from typing import Dict, List, Tuple
+
+from sqlalchemy.orm import Session
+
+from .. import models
+
+GENESIS_PREV_HASH = hashlib.sha256(b"CO-HR-AUDIT-GENESIS").hexdigest()
+
+
+@dataclass
+class HashChainReport:
+    status: str
+    entries_checked: int
+    issues: List[Dict[str, str]] = field(default_factory=list)
+
+
+def _serialise_entry(log: models.AuditLog) -> str:
+    parts = [
+        log.timestamp.isoformat(),
+        str(log.user_id or ""),
+        log.action,
+        str(log.entity_type or ""),
+        str(log.entity_id or ""),
+        log.details or "",
+        log.prev_hash or "",
+    ]
+    return "|".join(parts)
+
+
+def _compute_hash(payload: str) -> str:
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def append_audit_log(
+    db: Session,
+    *,
+    action: str,
+    user_id: int | None = None,
+    entity_type: str | None = None,
+    entity_id: int | None = None,
+    details: str | None = None,
+    timestamp: date | None = None,
+) -> models.AuditLog:
+    """Create a new ``AuditLog`` entry that extends the hash chain."""
+
+    timestamp = timestamp or date.today()
+    last_entry = db.query(models.AuditLog).order_by(models.AuditLog.id.desc()).first()
+    prev_hash = last_entry.entry_hash if last_entry and last_entry.entry_hash else GENESIS_PREV_HASH
+    retention_expires_at = timestamp + timedelta(days=365 * 4)
+
+    log = models.AuditLog(
+        user_id=user_id,
+        action=action,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        timestamp=timestamp,
+        details=details,
+        prev_hash=prev_hash,
+        retention_expires_at=retention_expires_at,
+        legal_hold=False,
+    )
+    payload = _serialise_entry(log)
+    log.entry_hash = _compute_hash(payload)
+    db.add(log)
+    db.commit()
+    db.refresh(log)
+    return log
+
+
+def verify_hash_chain(db: Session) -> HashChainReport:
+    """Verify that the stored audit log entries form a valid hash chain."""
+
+    logs = db.query(models.AuditLog).order_by(models.AuditLog.id).all()
+    prev_hash = GENESIS_PREV_HASH
+    issues: List[Dict[str, str]] = []
+    for log in logs:
+        expected_prev = prev_hash
+        if (log.prev_hash or GENESIS_PREV_HASH) != expected_prev:
+            issues.append({
+                "id": str(log.id),
+                "issue": "prev_hash_mismatch",
+            })
+        payload = _serialise_entry(log)
+        expected_hash = _compute_hash(payload)
+        if not log.entry_hash or log.entry_hash != expected_hash:
+            issues.append({
+                "id": str(log.id),
+                "issue": "entry_hash_mismatch",
+            })
+        prev_hash = log.entry_hash or expected_hash
+    status = "pass" if not issues else "fail"
+    return HashChainReport(status=status, entries_checked=len(logs), issues=issues)
+
+
+def export_audit_logs(db: Session, fmt: str = "json") -> Tuple[str, str, str]:
+    """Export audit logs as CSV or JSON with a detached HMAC signature."""
+
+    logs = db.query(models.AuditLog).order_by(models.AuditLog.id).all()
+    if fmt not in {"json", "csv"}:
+        raise ValueError("format must be 'json' or 'csv'")
+
+    if fmt == "json":
+        import json
+
+        payload = json.dumps([
+            {
+                "id": log.id,
+                "user_id": log.user_id,
+                "action": log.action,
+                "entity_type": log.entity_type,
+                "entity_id": log.entity_id,
+                "timestamp": log.timestamp.isoformat(),
+                "details": log.details,
+                "prev_hash": log.prev_hash,
+                "entry_hash": log.entry_hash,
+            }
+            for log in logs
+        ])
+        mime = "application/json"
+    else:
+        import csv
+        from io import StringIO
+
+        buffer = StringIO()
+        writer = csv.writer(buffer)
+        writer.writerow([
+            "id",
+            "user_id",
+            "action",
+            "entity_type",
+            "entity_id",
+            "timestamp",
+            "details",
+            "prev_hash",
+            "entry_hash",
+        ])
+        for log in logs:
+            writer.writerow([
+                log.id,
+                log.user_id,
+                log.action,
+                log.entity_type,
+                log.entity_id,
+                log.timestamp.isoformat(),
+                log.details,
+                log.prev_hash,
+                log.entry_hash,
+            ])
+        payload = buffer.getvalue()
+        mime = "text/csv"
+
+    key = os.getenv("AUDIT_EXPORT_SIGNING_KEY", "co-hr-demo-key").encode("utf-8")
+    signature = hmac.new(key, payload.encode("utf-8"), hashlib.sha256).hexdigest()
+    return payload, signature, mime

--- a/co-platform-expanded-final/co-platform/backend/app/services/health.py
+++ b/co-platform-expanded-final/co-platform/backend/app/services/health.py
@@ -1,0 +1,85 @@
+"""Health reporting helpers."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from .audit_chain import verify_hash_chain
+from .jobs import nightly_job_manager
+from .metrics import metrics_collector
+
+
+def build_health_report(db: Session) -> Dict[str, object]:
+    issues: List[str] = []
+    components: Dict[str, Dict[str, object]] = {}
+
+    # Database health
+    try:
+        db.execute(text("SELECT 1"))
+        components["database"] = {"status": "ok"}
+    except Exception as exc:  # pragma: no cover - defensive
+        components["database"] = {"status": "error", "detail": str(exc)}
+        issues.append("Database connection unavailable")
+
+    # Audit chain
+    try:
+        report = verify_hash_chain(db)
+        status = "ok" if report.status == "pass" else "degraded"
+        components["audit_chain"] = {
+            "status": status,
+            "chain_status": report.status,
+            "entries_checked": report.entries_checked,
+            "issues": report.issues,
+        }
+        if report.status != "pass":
+            issues.append("Audit hash chain verification failed")
+    except Exception as exc:  # pragma: no cover - defensive
+        components["audit_chain"] = {"status": "error", "detail": str(exc)}
+        issues.append("Audit verification error")
+
+    # Nightly jobs
+    job_state = nightly_job_manager.state()
+    job_results = job_state.get("results", {})
+    if not job_state.get("last_run"):
+        components["nightly_jobs"] = {"status": "degraded", "detail": "No runs recorded"}
+        issues.append("Nightly jobs have not executed yet")
+    else:
+        degraded = [name for name, info in job_results.items() if info["status"] not in {"success", "skipped"}]
+        components["nightly_jobs"] = {
+            "status": "ok" if not degraded else "degraded",
+            "last_run": job_state["last_run"],
+            "alerts": job_state.get("alerts", []),
+            "degraded_jobs": degraded,
+        }
+        if degraded:
+            issues.extend([f"Nightly job {name} reported {job_results[name]['status']}" for name in degraded])
+        if job_state.get("alerts"):
+            issues.extend(job_state["alerts"])
+
+    # Email services from metrics snapshot
+    snapshot = metrics_collector.snapshot()
+    imap = snapshot["imap"]
+    smtp = snapshot["smtp"]
+    email_status = "ok"
+    email_detail: Dict[str, object] = {"imap": imap, "smtp": smtp}
+    if imap["fail"] and not imap["success"]:
+        email_status = "degraded"
+        issues.append("IMAP fetch failures detected")
+    if smtp["fail"] and not smtp["success"]:
+        email_status = "degraded"
+        issues.append("SMTP delivery failures detected")
+    components["email"] = {"status": email_status, **email_detail}
+
+    overall_status = "ok" if not issues else "degraded"
+    return {"status": overall_status, "components": components, "issues": issues, "metrics": snapshot}
+
+
+def readiness_check(db: Session) -> Dict[str, str]:
+    try:
+        db.execute(text("SELECT 1"))
+        return {"status": "ready"}
+    except Exception as exc:  # pragma: no cover - defensive
+        return {"status": "error", "detail": str(exc)}

--- a/co-platform-expanded-final/co-platform/backend/app/services/jobs.py
+++ b/co-platform-expanded-final/co-platform/backend/app/services/jobs.py
@@ -1,0 +1,222 @@
+"""Nightly job scheduler and helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from contextlib import suppress
+from dataclasses import dataclass, field
+from datetime import date, datetime, time as dtime, timedelta
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from sqlalchemy.orm import Session, sessionmaker
+
+from .. import models
+from . import retention
+from .audit_chain import append_audit_log, verify_hash_chain
+from .metrics import metrics_collector
+
+BACKUP_RETENTION_DAYS = 14
+BACKUP_DIR = Path(__file__).resolve().parent.parent / "static" / "backups"
+
+
+@dataclass
+class JobResult:
+    name: str
+    status: str
+    detail: Dict[str, object] = field(default_factory=dict)
+    error: Optional[str] = None
+
+
+class NightlyJobManager:
+    def __init__(self) -> None:
+        self._session_factory: Optional[sessionmaker] = None
+        self._stop_event = asyncio.Event()
+        self._last_run: Optional[datetime] = None
+        self._last_results: Dict[str, JobResult] = {}
+        self._alerts: List[str] = []
+        self._lock = asyncio.Lock()
+
+    def configure(self, session_factory: sessionmaker) -> None:
+        self._session_factory = session_factory
+
+    async def run_scheduler(self) -> None:
+        if self._session_factory is None:
+            raise RuntimeError("NightlyJobManager not configured with a session factory")
+        while not self._stop_event.is_set():
+            wait_seconds = self._seconds_until_window()
+            try:
+                await asyncio.wait_for(self._stop_event.wait(), timeout=wait_seconds)
+                if self._stop_event.is_set():
+                    break
+            except asyncio.TimeoutError:
+                pass
+            await self.run_once()
+
+    async def run_once(self) -> None:
+        if self._session_factory is None:
+            raise RuntimeError("NightlyJobManager not configured with a session factory")
+        async with self._lock:
+            results: Dict[str, JobResult] = {}
+            alerts: List[str] = []
+            session: Session = self._session_factory()
+            try:
+                results["probation_reminders"] = self._probation_reminders(session)
+                results["retention_cleanup"] = self._retention_cleanup(session)
+                results["database_backup"] = self._database_backup()
+                results["audit_chain_verification"] = self._audit_chain_verification(session)
+                results["imap_fetch"] = self._imap_fetch()
+                for result in results.values():
+                    if result.status not in {"success", "skipped"}:
+                        alerts.append(f"Job {result.name} {result.status}")
+                ticket_count = session.query(models.Ticket).filter(models.Ticket.status == models.TicketStatus.open).count()
+                metrics_collector.set_open_ticket_count(ticket_count)
+                summary = {
+                    name: {
+                        "status": result.status,
+                        "detail": result.detail,
+                        "error": result.error,
+                    }
+                    for name, result in results.items()
+                }
+                append_audit_log(
+                    session,
+                    action="nightly.jobs",
+                    details=json.dumps({"status": "ok" if not alerts else "issues", "jobs": summary}),
+                )
+                if alerts:
+                    alerts.append("Alerts dispatched for failing jobs")
+                    metrics_collector.record_email_attempt("smtp", False)
+            finally:
+                session.close()
+            self._alerts = alerts
+            self._last_results = results
+            self._last_run = datetime.utcnow()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def state(self) -> Dict[str, object]:
+        return {
+            "last_run": self._last_run.isoformat() if self._last_run else None,
+            "results": {
+                name: {
+                    "status": result.status,
+                    "detail": result.detail,
+                    "error": result.error,
+                }
+                for name, result in self._last_results.items()
+            },
+            "alerts": list(self._alerts),
+        }
+
+    # ------------------------------------------------------------------
+    # Individual jobs
+    # ------------------------------------------------------------------
+    def _probation_reminders(self, session: Session) -> JobResult:
+        start = datetime.utcnow()
+        try:
+            today = date.today()
+            upcoming = today + timedelta(days=7)
+            probations = (
+                session.query(models.ProbationStatus)
+                .filter(models.ProbationStatus.end_date >= today, models.ProbationStatus.end_date <= upcoming)
+                .all()
+            )
+            success = True
+            detail = {"count": len(probations)}
+            error = None
+        except Exception as exc:  # pragma: no cover - defensive
+            success = False
+            detail = {}
+            error = str(exc)
+        duration = (datetime.utcnow() - start).total_seconds()
+        metrics_collector.record_job("probation_reminders", duration, success, error)
+        status = "success" if success else "failed"
+        return JobResult(name="probation_reminders", status=status, detail=detail, error=error)
+
+    def _retention_cleanup(self, session: Session) -> JobResult:
+        start = datetime.utcnow()
+        try:
+            summary = retention.cleanup_expired_records(session)
+            status = "success"
+            error = None
+        except Exception as exc:
+            summary = {}
+            status = "failed"
+            error = str(exc)
+        duration = (datetime.utcnow() - start).total_seconds()
+        metrics_collector.record_job("retention_cleanup", duration, status == "success", error)
+        return JobResult(name="retention_cleanup", status=status, detail=summary, error=error)
+
+    def _database_backup(self) -> JobResult:
+        start = datetime.utcnow()
+        try:
+            BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+            timestamp = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+            backup_file = BACKUP_DIR / f"backup-{timestamp}.sql"
+            backup_file.write_text("-- simulated backup --\n")
+            cutoff = datetime.utcnow() - timedelta(days=BACKUP_RETENTION_DAYS)
+            for file in BACKUP_DIR.glob("backup-*.sql"):
+                if datetime.utcfromtimestamp(file.stat().st_mtime) < cutoff:
+                    with suppress(OSError):
+                        file.unlink()
+            success = True
+            detail = {"file": str(backup_file)}
+            error = None
+        except Exception as exc:  # pragma: no cover - defensive
+            success = False
+            detail = {}
+            error = str(exc)
+        duration = (datetime.utcnow() - start).total_seconds()
+        metrics_collector.record_job("database_backup", duration, success, error)
+        status = "success" if success else "failed"
+        return JobResult(name="database_backup", status=status, detail=detail, error=error)
+
+    def _audit_chain_verification(self, session: Session) -> JobResult:
+        start = datetime.utcnow()
+        try:
+            report = verify_hash_chain(session)
+            success = report.status == "pass"
+            detail = {"entries_checked": report.entries_checked, "issues": report.issues}
+            error = None if success else "hash chain mismatch"
+        except Exception as exc:  # pragma: no cover - defensive
+            success = False
+            detail = {}
+            error = str(exc)
+            report = None
+        duration = (datetime.utcnow() - start).total_seconds()
+        metrics_collector.record_job("audit_chain_verification", duration, success, error)
+        status = "success" if success else "failed"
+        if report is None:
+            detail = {}
+        return JobResult(name="audit_chain_verification", status=status, detail=detail, error=error)
+
+    def _imap_fetch(self) -> JobResult:
+        start = datetime.utcnow()
+        host = os.getenv("IMAP_HOST")
+        if not host:
+            metrics_collector.record_email_attempt("imap", False)
+            duration = (datetime.utcnow() - start).total_seconds()
+            metrics_collector.record_job("imap_fetch", duration, True)
+            return JobResult(name="imap_fetch", status="skipped", detail={"reason": "IMAP not configured"})
+        # In this environment we cannot connect to external services.
+        metrics_collector.record_email_attempt("imap", False)
+        duration = (datetime.utcnow() - start).total_seconds()
+        metrics_collector.record_job("imap_fetch", duration, False, "connection not available")
+        return JobResult(name="imap_fetch", status="degraded", error="Unable to reach IMAP host")
+
+    # ------------------------------------------------------------------
+    # Timing helpers
+    # ------------------------------------------------------------------
+    def _seconds_until_window(self) -> float:
+        now = datetime.utcnow()
+        target = datetime.combine(now.date(), dtime(hour=2, minute=0))
+        if now >= target:
+            target += timedelta(days=1)
+        return max((target - now).total_seconds(), 0.0)
+
+
+nightly_job_manager = NightlyJobManager()

--- a/co-platform-expanded-final/co-platform/backend/app/services/metrics.py
+++ b/co-platform-expanded-final/co-platform/backend/app/services/metrics.py
@@ -1,0 +1,153 @@
+"""Simple in-process metrics collector.
+
+The real system would push metrics to a monitoring backend. For this
+exercise we keep them in memory so the ``/metrics`` endpoint can expose
+prometheus-style text as well as structured JSON used by the System
+Health widgets.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Deque, Dict
+
+
+@dataclass
+class RequestMetric:
+    """Aggregated information for a single request path."""
+
+    count: int = 0
+    failures: int = 0
+    durations: Deque[float] = field(default_factory=lambda: deque(maxlen=500))
+
+
+@dataclass
+class JobMetric:
+    """Stores duration history for nightly jobs."""
+
+    durations: Deque[float] = field(default_factory=lambda: deque(maxlen=30))
+    last_success: bool = True
+    last_error: str | None = None
+
+
+class MetricsCollector:
+    """Thread-safe metric store used across the app."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._requests: Dict[str, RequestMetric] = defaultdict(RequestMetric)
+        self._jobs: Dict[str, JobMetric] = defaultdict(JobMetric)
+        self._imap = {"success": 0, "fail": 0}
+        self._smtp = {"success": 0, "fail": 0}
+        self._open_ticket_count: int = 0
+
+    # ------------------------------------------------------------------
+    # Request metrics
+    # ------------------------------------------------------------------
+    def record_request(self, path: str, duration: float, success: bool) -> None:
+        with self._lock:
+            metric = self._requests[path]
+            metric.count += 1
+            if not success:
+                metric.failures += 1
+            metric.durations.append(duration)
+
+    def _request_snapshot(self) -> Dict[str, Dict[str, float]]:
+        snapshot: Dict[str, Dict[str, float]] = {}
+        with self._lock:
+            for path, metric in self._requests.items():
+                durations = list(metric.durations)
+                if durations:
+                    sorted_durations = sorted(durations)
+                    index = max(int(len(sorted_durations) * 0.95) - 1, 0)
+                    p95 = sorted_durations[index]
+                    avg = sum(sorted_durations) / len(sorted_durations)
+                else:
+                    p95 = 0.0
+                    avg = 0.0
+                snapshot[path] = {
+                    "count": metric.count,
+                    "failures": metric.failures,
+                    "p95": p95,
+                    "avg": avg,
+                }
+        return snapshot
+
+    # ------------------------------------------------------------------
+    # Job metrics
+    # ------------------------------------------------------------------
+    def record_job(self, job_name: str, duration: float, success: bool, error: str | None = None) -> None:
+        with self._lock:
+            metric = self._jobs[job_name]
+            metric.durations.append(duration)
+            metric.last_success = success
+            metric.last_error = error
+
+    def _job_snapshot(self) -> Dict[str, Dict[str, float | bool | str | None]]:
+        snapshot: Dict[str, Dict[str, float | bool | str | None]] = {}
+        with self._lock:
+            for name, metric in self._jobs.items():
+                durations = list(metric.durations)
+                avg = sum(durations) / len(durations) if durations else 0.0
+                snapshot[name] = {
+                    "avg_duration": avg,
+                    "last_duration": durations[-1] if durations else 0.0,
+                    "last_success": metric.last_success,
+                    "last_error": metric.last_error,
+                }
+        return snapshot
+
+    # ------------------------------------------------------------------
+    # Email/Ticket helpers
+    # ------------------------------------------------------------------
+    def record_email_attempt(self, protocol: str, success: bool) -> None:
+        target = self._imap if protocol.lower() == "imap" else self._smtp
+        key = "success" if success else "fail"
+        with self._lock:
+            target[key] += 1
+
+    def set_open_ticket_count(self, count: int) -> None:
+        with self._lock:
+            self._open_ticket_count = count
+
+    # ------------------------------------------------------------------
+    # Snapshot / Export
+    # ------------------------------------------------------------------
+    def snapshot(self) -> Dict[str, object]:
+        return {
+            "requests": self._request_snapshot(),
+            "jobs": self._job_snapshot(),
+            "imap": self._imap.copy(),
+            "smtp": self._smtp.copy(),
+            "open_tickets": self._open_ticket_count,
+        }
+
+    def render_prometheus(self) -> str:
+        data = self.snapshot()
+        lines = ["# HELP http_requests_total Total HTTP requests", "# TYPE http_requests_total counter"]
+        for path, info in data["requests"].items():
+            lines.append(f'http_requests_total{{path="{path}"}} {info["count"]}')
+            lines.append(f'http_requests_failures_total{{path="{path}"}} {info["failures"]}')
+            lines.append(f'http_request_duration_seconds_avg{{path="{path}"}} {info["avg"]}')
+            lines.append(f'http_request_duration_seconds_p95{{path="{path}"}} {info["p95"]}')
+        lines.append("# HELP nightly_job_duration_seconds Average job duration")
+        lines.append("# TYPE nightly_job_duration_seconds gauge")
+        for job, info in data["jobs"].items():
+            lines.append(f'nightly_job_duration_seconds{{job="{job}"}} {info["avg_duration"]}')
+            success = 1 if info["last_success"] else 0
+            lines.append(f'nightly_job_last_success{{job="{job}"}} {success}')
+        lines.append("# HELP email_attempts_total Email send/receive attempts")
+        lines.append("# TYPE email_attempts_total counter")
+        lines.append(f'email_attempts_total{{protocol="imap",result="success"}} {data["imap"]["success"]}')
+        lines.append(f'email_attempts_total{{protocol="imap",result="fail"}} {data["imap"]["fail"]}')
+        lines.append(f'email_attempts_total{{protocol="smtp",result="success"}} {data["smtp"]["success"]}')
+        lines.append(f'email_attempts_total{{protocol="smtp",result="fail"}} {data["smtp"]["fail"]}')
+        lines.append("# HELP open_tickets Number of open tickets")
+        lines.append("# TYPE open_tickets gauge")
+        lines.append(f'open_tickets {data["open_tickets"]}')
+        return "\n".join(lines)
+
+
+metrics_collector = MetricsCollector()

--- a/co-platform-expanded-final/co-platform/backend/app/services/retention.py
+++ b/co-platform-expanded-final/co-platform/backend/app/services/retention.py
@@ -1,0 +1,135 @@
+"""Retention management helpers."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Dict, Iterable, Tuple
+
+from sqlalchemy.orm import Session
+
+from .. import models
+
+DEFAULT_RETENTION_YEARS = 4
+
+
+def _cutoff(retention_years: int) -> date:
+    return date.today() - timedelta(days=retention_years * 365)
+
+
+def _extension_lookup(db: Session) -> Dict[Tuple[str, int], models.RetentionExtension]:
+    extensions = db.query(models.RetentionExtension).all()
+    return {(ext.entity_type, ext.entity_id): ext for ext in extensions}
+
+
+def _is_extended(obj, entity_type: str, extensions: Dict[Tuple[str, int], models.RetentionExtension]) -> bool:
+    if not hasattr(obj, "id"):
+        return False
+    extension = extensions.get((entity_type, obj.id))
+    return bool(extension and extension.extended_until >= date.today())
+
+
+def _anonymise(obj, fields: Iterable[str]) -> bool:
+    changed = False
+    for field in fields:
+        if hasattr(obj, field):
+            setattr(obj, field, "[ANONYMIZED]")
+            changed = True
+    return changed
+
+
+def cleanup_expired_records(
+    db: Session,
+    retention_years: int = DEFAULT_RETENTION_YEARS,
+) -> Dict[str, Dict[str, int]]:
+    """Remove or anonymise data older than the configured retention window."""
+
+    cutoff = _cutoff(retention_years)
+    extensions = _extension_lookup(db)
+    results: Dict[str, Dict[str, int]] = {}
+
+    def process(query, model_name: str, date_field: str, anonymise_fields: Iterable[str] | None = None) -> None:
+        anonymise_fields = anonymise_fields or []
+        table = getattr(models, model_name)
+        field = getattr(table, date_field)
+        expired = query.filter(field < cutoff).all()
+        anonymised = 0
+        deleted = 0
+        for obj in expired:
+            if getattr(obj, "legal_hold", False) or _is_extended(obj, model_name, extensions):
+                continue
+            if anonymise_fields and _anonymise(obj, anonymise_fields):
+                anonymised += 1
+            else:
+                db.delete(obj)
+                deleted += 1
+        if anonymised or deleted:
+            results[model_name] = {"anonymised": anonymised, "deleted": deleted}
+
+    process(db.query(models.LeaveRequest), "LeaveRequest", "end_date", ["reason"])
+    process(db.query(models.Incident), "Incident", "date", ["description"])
+    process(db.query(models.Appeal), "Appeal", "created_at", ["reason"])
+    process(db.query(models.BragEntry), "BragEntry", "date", ["notes"])
+    process(db.query(models.ProbationStatus), "ProbationStatus", "end_date", ["notes"])
+    # Only completed training records have a completion date worth checking
+    completed_training = db.query(models.TrainingStatus).filter(
+        models.TrainingStatus.completed == True,
+        models.TrainingStatus.completion_date < cutoff,
+    ).all()
+    anonymised_training = 0
+    deleted_training = 0
+    for record in completed_training:
+        if getattr(record, "legal_hold", False) or _is_extended(record, "TrainingStatus", extensions):
+            continue
+        if _anonymise(record, ["module_name"]):
+            anonymised_training += 1
+        else:
+            db.delete(record)
+            deleted_training += 1
+    if anonymised_training or deleted_training:
+        results["TrainingStatus"] = {"anonymised": anonymised_training, "deleted": deleted_training}
+
+    process(db.query(models.Offboarding), "Offboarding", "date", [])
+    process(db.query(models.Attachment), "Attachment", "uploaded_at", ["file_name", "file_path"])
+    process(db.query(models.AuditLog), "AuditLog", "timestamp", ["details"])
+
+    db.commit()
+    return results
+
+
+def upsert_extension(
+    db: Session,
+    *,
+    entity_type: str,
+    entity_id: int,
+    extended_until: date,
+    reason: str | None,
+) -> models.RetentionExtension:
+    record = (
+        db.query(models.RetentionExtension)
+        .filter(
+            models.RetentionExtension.entity_type == entity_type,
+            models.RetentionExtension.entity_id == entity_id,
+        )
+        .one_or_none()
+    )
+    if record is None:
+        record = models.RetentionExtension(
+            entity_type=entity_type,
+            entity_id=entity_id,
+            extended_until=extended_until,
+            reason=reason,
+        )
+        db.add(record)
+    else:
+        record.extended_until = extended_until
+        record.reason = reason
+    db.commit()
+    db.refresh(record)
+    return record
+
+
+def delete_extension(db: Session, extension_id: int) -> None:
+    record = db.query(models.RetentionExtension).filter(models.RetentionExtension.id == extension_id).one_or_none()
+    if record:
+        db.delete(record)
+        db.commit()

--- a/co-platform-expanded-final/co-platform/frontend/src/lib/api.js
+++ b/co-platform-expanded-final/co-platform/frontend/src/lib/api.js
@@ -534,7 +534,7 @@ export async function createAttachment(att) {
 //
 
 export async function listAuditLogs() {
-  const res = await fetch(`${API_BASE}/audit-logs/`, {
+  const res = await fetch(`${API_BASE}/audit/logs`, {
     headers: {
       'Accept': 'application/json',
       ...getAuthHeaders(),
@@ -542,6 +542,45 @@ export async function listAuditLogs() {
   });
   if (!res.ok) {
     throw new Error('Failed to fetch audit logs');
+  }
+  return res.json();
+}
+
+export async function verifyAuditHashChain() {
+  const res = await fetch(`${API_BASE}/audit/verify-hash-chain`, {
+    headers: {
+      'Accept': 'application/json',
+      ...getAuthHeaders(),
+    },
+  });
+  if (!res.ok) {
+    throw new Error('Failed to verify audit chain');
+  }
+  return res.json();
+}
+
+export async function exportAuditLogs(format = 'json') {
+  const res = await fetch(`${API_BASE}/audit/export?fmt=${format}`, {
+    headers: {
+      'Accept': 'application/json',
+      ...getAuthHeaders(),
+    },
+  });
+  if (!res.ok) {
+    throw new Error('Failed to export audit logs');
+  }
+  return res.json();
+}
+
+export async function getHealthStatus() {
+  const res = await fetch(`${API_BASE}/health`, {
+    headers: {
+      'Accept': 'application/json',
+      ...getAuthHeaders(),
+    },
+  });
+  if (!res.ok) {
+    throw new Error('Failed to fetch health status');
   }
   return res.json();
 }

--- a/co-platform-expanded-final/co-platform/frontend/src/pages/Dashboard.jsx
+++ b/co-platform-expanded-final/co-platform/frontend/src/pages/Dashboard.jsx
@@ -5,6 +5,7 @@ import {
   getTickets,
   getOnboardingStatus,
   getIncidents,
+  getHealthStatus,
 } from '../lib/api.js';
 
 import { Link } from 'react-router-dom';
@@ -21,29 +22,74 @@ export default function DashboardPage() {
   const [tickets, setTickets] = useState([]);
   const [onboarding, setOnboarding] = useState(null);
   const [incidents, setIncidents] = useState([]);
+  const [health, setHealth] = useState(null);
   const [error, setError] = useState('');
 
   useEffect(() => {
+    let cancelled = false;
     async function fetchData() {
-      try {
-        const [probationData, leaveData, ticketData, onboardingData, incidentData] = await Promise.all([
-          getProbations(),
-          getLeaves(),
-          getTickets(),
-          getOnboardingStatus(),
-          getIncidents(),
-        ]);
-        setProbations(probationData || []);
-        setLeaves(leaveData || []);
-        setTickets(ticketData || []);
-        setOnboarding(onboardingData || null);
-        setIncidents(incidentData || []);
-      } catch (err) {
-        console.error(err);
-        setError('Failed to load dashboard data');
+      const loaders = [
+        {
+          label: 'probations',
+          fn: getProbations,
+          apply: (value) => setProbations(value || []),
+          onError: () => setProbations([]),
+        },
+        {
+          label: 'leaves',
+          fn: getLeaves,
+          apply: (value) => setLeaves(value || []),
+          onError: () => setLeaves([]),
+        },
+        {
+          label: 'tickets',
+          fn: getTickets,
+          apply: (value) => setTickets(value || []),
+          onError: () => setTickets([]),
+        },
+        {
+          label: 'onboarding',
+          fn: getOnboardingStatus,
+          apply: (value) => setOnboarding(value || null),
+          onError: () => setOnboarding(null),
+        },
+        {
+          label: 'incidents',
+          fn: getIncidents,
+          apply: (value) => setIncidents(value || []),
+          onError: () => setIncidents([]),
+        },
+        {
+          label: 'health',
+          fn: getHealthStatus,
+          apply: (value) => setHealth(value || null),
+          onError: () => setHealth(null),
+        },
+      ];
+
+      const results = await Promise.allSettled(loaders.map((loader) => loader.fn()));
+      const errors = [];
+      results.forEach((result, idx) => {
+        if (cancelled) {
+          return;
+        }
+        const loader = loaders[idx];
+        if (result.status === 'fulfilled') {
+          loader.apply(result.value);
+        } else {
+          console.error(`Failed to load ${loader.label}`, result.reason);
+          loader.onError();
+          errors.push(loader.label);
+        }
+      });
+      if (!cancelled) {
+        setError(errors.length ? `Some data is unavailable: ${errors.join(', ')}` : '');
       }
     }
     fetchData();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // Compute derived metrics
@@ -114,13 +160,54 @@ export default function DashboardPage() {
   recentEvents.sort((a, b) => new Date(b.date) - new Date(a.date));
   const latestEvents = recentEvents.slice(0, 5);
 
-  // Static system health status
-  const systemHealth = [
-    { name: 'Database', status: 'Healthy', color: 'text-green-400' },
-    { name: 'Email Service', status: 'N/A', color: 'text-gray-400' },
-    { name: 'Audit Chain', status: 'Healthy', color: 'text-green-400' },
-    { name: 'Next Check', status: 'Jan 15, 02:00', color: 'text-gray-400' },
-  ];
+  const formatHealthName = (raw) => raw.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+
+  const systemHealth = health
+    ? Object.entries(health.components || {}).map(([key, info]) => {
+        const statusValue = info.status || 'unknown';
+        let color = 'text-gray-400';
+        if (statusValue === 'ok') color = 'text-green-400';
+        else if (statusValue === 'degraded') color = 'text-yellow-400';
+        else if (statusValue === 'error' || statusValue === 'failed') color = 'text-red-400';
+        else if (statusValue === 'skipped') color = 'text-blue-400';
+        const statusLabel =
+          statusValue === 'ok'
+            ? 'Healthy'
+            : statusValue.charAt(0).toUpperCase() + statusValue.slice(1);
+        const details = [];
+        if (info.chain_status && info.chain_status !== 'pass') {
+          details.push(`Chain: ${info.chain_status}`);
+        }
+        if (Array.isArray(info.degraded_jobs) && info.degraded_jobs.length > 0) {
+          details.push(`Jobs: ${info.degraded_jobs.join(', ')}`);
+        }
+        if (Array.isArray(info.alerts) && info.alerts.length > 0) {
+          details.push(`Alerts: ${info.alerts.join('; ')}`);
+        }
+        if (Array.isArray(info.issues) && info.issues.length > 0) {
+          details.push(`${info.issues.length} issue(s)`);
+        }
+        if (info.entries_checked !== undefined) {
+          details.push(`${info.entries_checked} entries checked`);
+        }
+        if (info.detail) {
+          details.push(info.detail);
+        }
+        if (info.last_run) {
+          details.push(`Last run: ${new Date(info.last_run).toLocaleString()}`);
+        }
+        if (key === 'email' && info.imap && info.smtp) {
+          details.push(`IMAP ${info.imap.success}/${info.imap.fail} success/fail`);
+          details.push(`SMTP ${info.smtp.success}/${info.smtp.fail} success/fail`);
+        }
+        return {
+          name: formatHealthName(key),
+          status: statusLabel,
+          color,
+          details,
+        };
+      })
+    : [];
 
   return (
     <div className="space-y-6">
@@ -256,14 +343,39 @@ export default function DashboardPage() {
         {/* System health */}
         <div className="bg-gray-800 p-4 rounded-lg shadow">
           <h3 className="text-sm uppercase text-gray-400 mb-3">System Health</h3>
-          <ul className="space-y-1 text-sm">
-            {systemHealth.map((item) => (
-              <li key={item.name} className="flex justify-between">
-                <span>{item.name}</span>
-                <span className={item.color}>{item.status}</span>
-              </li>
-            ))}
-          </ul>
+          {health ? (
+            <>
+              <ul className="space-y-2 text-sm">
+                {systemHealth.map((item) => (
+                  <li key={item.name} className="flex flex-col border-b border-gray-700 pb-2 last:border-b-0 last:pb-0">
+                    <div className="flex justify-between">
+                      <span>{item.name}</span>
+                      <span className={item.color}>{item.status}</span>
+                    </div>
+                    {item.details.length > 0 && (
+                      <div className="mt-1 space-y-1 text-xs text-gray-400">
+                        {item.details.map((line, idx) => (
+                          <div key={`${item.name}-${idx}`}>{line}</div>
+                        ))}
+                      </div>
+                    )}
+                  </li>
+                ))}
+              </ul>
+              {health.issues && health.issues.length > 0 && (
+                <div className="mt-3 border-t border-gray-700 pt-2">
+                  <h4 className="text-xs uppercase text-gray-500 mb-1">Reported Issues</h4>
+                  <ul className="space-y-1 text-xs text-gray-400">
+                    {health.issues.map((issue, idx) => (
+                      <li key={`issue-${idx}`}>• {issue}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </>
+          ) : (
+            <p className="text-gray-500 text-sm">Health data unavailable.</p>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add FastAPI health, readiness, and metrics endpoints backed by an in-process metrics collector and nightly job state
- extend the audit log with hash-chain fields, verification/export endpoints, and retention override support
- update the dashboard and client utilities to surface component health while tolerating partial data failures

## Testing
- python -m compileall app
- npm install --no-audit --no-fund *(fails: registry returned 403 for @vitejs/plugin-react)*

------
https://chatgpt.com/codex/tasks/task_b_68d763394680832698027ffc6b014889