### PR TITLE
Document setup steps and add missing dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+venv/
+node_modules/
+*.pyc
+__pycache__/

--- a/co-platform-expanded-final/co-platform/README.md
+++ b/co-platform-expanded-final/co-platform/README.md
@@ -103,23 +103,37 @@ To run services manually:
 1. Install dependencies:
 
    ```bash
-   # Backend
+   # Backend (Python 3.11+ recommended)
    cd backend
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install --upgrade pip
    pip install -r requirements.txt
 
-   # Frontend
+   # Frontend (Node.js 20+)
    cd ../frontend
    npm install
    ```
 
-2. Create a PostgreSQL database (or use SQLite) and set the `DATABASE_URL`
-   environment variable accordingly. Copy `.env.example` to `.env` and
-   configure `JWT_SECRET` and `ALLOWED_ORIGINS`.
+2. Provision a database and environment variables:
+
+   - Start a PostgreSQL instance (for example via Docker: `docker run -p 5432:5432 -e POSTGRES_PASSWORD=password postgres:15`).
+   - Decide on a connection string (e.g. `postgresql://postgres:password@localhost:5432/postgres`).
+   - Export the required environment variables before running the backend:
+
+     ```bash
+     export DATABASE_URL="postgresql://postgres:password@localhost:5432/postgres"
+     export JWT_SECRET="change-me"
+     export ALLOWED_ORIGINS="http://localhost:5173"
+     ```
+
+     > You can use SQLite for quick demos by setting `DATABASE_URL="sqlite:///./dev.db"`.
 
 3. Start the backend:
 
    ```bash
    cd backend
+   source .venv/bin/activate
    uvicorn app.main:app --reload --port 8000
    ```
 
@@ -127,11 +141,26 @@ To run services manually:
 
    ```bash
    cd frontend
-   npm run dev
+   npm run dev -- --host
    ```
 
 5. Access `http://localhost:5173` in your browser and complete the
    Getting Started wizard as above.
+
+## Required Environment Variables
+
+The backend reads configuration exclusively from environment variables. When
+running outside Docker make sure the following are set in your shell or
+process manager:
+
+| Variable | Description | Default (if unset) |
+| --- | --- | --- |
+| `DATABASE_URL` | SQLAlchemy connection string. Use PostgreSQL in production or SQLite for quick demos. | `postgresql://postgres:password@db:5432/postgres` |
+| `JWT_SECRET` | Secret key for signing JSON Web Tokens. Change this to a strong random value. | `supersecret` |
+| `ALLOWED_ORIGINS` | Comma-separated list of origins allowed by CORS. | `http://localhost:5173` |
+
+You can persist these in a shell script (e.g. `backend/env.local`) and `source`
+it before launching the backend.
 
 ## Configuring Webhooks
 

--- a/co-platform-expanded-final/co-platform/README_for_dummies.md
+++ b/co-platform-expanded-final/co-platform/README_for_dummies.md
@@ -1,0 +1,79 @@
+# CO HR Platform – Super Simple Guide
+
+This guide is for anyone who just wants to see the site running without
+worrying about the extra details. Follow each step in order.
+
+## Option A: Quick start with Docker (easiest)
+
+1. Install **Docker Desktop** (includes Docker Compose).
+2. Open a terminal in the `co-platform` folder.
+3. Run:
+   ```bash
+   docker compose up --build
+   ```
+4. Wait until you see messages that the web server is ready on port 5173.
+5. Open your browser at <http://localhost:5173>.
+6. The first screen lets you set up the organisation name and first admin user.
+   Fill in the form and submit it to log in.
+
+To stop everything press `Ctrl+C` in the terminal, then run:
+```bash
+docker compose down
+```
+
+## Option B: Run it yourself (for laptops without Docker)
+
+### 1. Get the tools
+- Install **Python 3.11 or newer**.
+- Install **Node.js 20 or newer** (this gives you `npm`).
+- Install **PostgreSQL** or be ready to use SQLite.
+
+### 2. Back-end (API)
+```bash
+cd co-platform/backend
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+Set the environment variables (you can paste these into the same terminal):
+```bash
+export DATABASE_URL="postgresql://postgres:password@localhost:5432/postgres"
+export JWT_SECRET="change-me"
+export ALLOWED_ORIGINS="http://localhost:5173"
+```
+> Tip: No database? Replace `DATABASE_URL` with `sqlite:///./dev.db` to create a
+> SQLite file next to the code.
+
+Start the API:
+```bash
+uvicorn app.main:app --reload --port 8000
+```
+
+### 3. Front-end (website)
+Open a **second** terminal:
+```bash
+cd co-platform/frontend
+npm install
+npm run dev -- --host
+```
+
+### 4. Use the site
+- Visit <http://localhost:5173>.
+- Complete the Getting Started form to create the first admin.
+- After you log in you can explore Tickets, Leaves, Approvals, etc.
+
+## Need to start again?
+- Delete the SQLite file (`dev.db`) or reset your Postgres database.
+- Clear your browser local storage if you stay logged in.
+
+## Common issues
+- **`pip install` or `npm install` fails:** check your internet connection or
+  proxy settings.
+- **Cannot connect to database:** make sure the `DATABASE_URL` points to a
+  running database and the credentials are correct.
+- **Blocked by CORS:** confirm `ALLOWED_ORIGINS` includes the URL you load the
+  site from (usually `http://localhost:5173`).
+
+You now have the platform running! 🚀

--- a/co-platform-expanded-final/co-platform/backend/requirements.txt
+++ b/co-platform-expanded-final/co-platform/backend/requirements.txt
@@ -1,4 +1,5 @@
 fastapi
+email-validator
 uvicorn[standard]
 sqlalchemy>=1.4
 pydantic>=2.0


### PR DESCRIPTION
## Summary
- add the missing email-validator package to the backend requirements
- update the main README with clearer manual setup steps and an environment variable reference
- add a simplified "for dummies" README and ignore common local build artifacts

## Testing
- ⚠️ `pip install -r co-platform-expanded-final/co-platform/backend/requirements.txt` *(fails in this environment: outbound package downloads blocked by proxy)*
- ⚠️ `npm install` *(fails in this environment: outbound package downloads blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68d7668fff588326bcabc0571715e0f5